### PR TITLE
Arreglar calendario, considera eventos sin nombre

### DIFF
--- a/client/src/components/Calendario.vue
+++ b/client/src/components/Calendario.vue
@@ -50,10 +50,9 @@
           ref="calendar"
           v-model="focus"
           color="primary"
-          :events="citas"
+          :events="events"
           :now="today"
           :type="type"
-          :headers="headers"
           @click:event="showEvent"
           @click:more="viewDay"
           @click:date="viewDay"
@@ -128,7 +127,7 @@
       selectedEvent: {},
       selectedElement: null,
       selectedOpen: false,
-      citas: [],
+      events: [],
       dialog: false
     }),
     created: function(){
@@ -167,17 +166,22 @@
   },
     methods: {
      async getCalendarAppointments() {
+
       const response = await calendarService.getCalendarAppointments({
         headers: {
             uid: localStorage.uid,
         }
       });
-      console.log(localStorage.uid);
-      console.log("UID");
-      this.citas = response.data.data;
-      console.log("Holaa");
-      console.log(this.citas);
-      console.log(response.data.data);
+
+      this.events = response.data.data
+
+      //Vuetify nos pide que tengamos (name, start) para que se pueda ver el event
+      this.events.forEach(function (event) {
+          if(!event.hasAttribute("name")) {
+            event.name = " ";
+          }
+      })
+      console.log(this.events);
     },
     viewDay ({ date }) {
      this.focus = date

--- a/client/src/components/dialogs/AppointmentDialog.vue
+++ b/client/src/components/dialogs/AppointmentDialog.vue
@@ -20,11 +20,21 @@
           <v-list-item>
             <v-list-item-content>
               <v-col class="d-flex">
+                    <v-text-field
+                    v-model= "name"
+                    label="Nombre"
+                    ></v-text-field>
+            </v-col>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <v-col class="d-flex">
                     <v-select
                     :items="hospitales"
                     item-value="id" 
                     v-model= "hospitalId"
-                    item-text="hospitalName"
+                    item-text="hospital"
                     label="Hospital"
                     ></v-select>
             </v-col>
@@ -124,6 +134,7 @@
         // Funcion que registra cita en base de datos.
         async postAppointment() {
             var appointmentObject = {
+                name: this.name,
                 hospital: this.hospitalId,
                 doctor: this.doctorId,
                 date: this.picker,

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -309,6 +309,7 @@ app.post('/appointments', (req, res) => {
   const uid = req.headers.uid;
 
   const cita_medica = {
+      name: req.body.appointment.name,
       created: Date.now(),
       exme_medico_id: "",
       exme_paciente_id: req.body.uid,


### PR DESCRIPTION
El problema de por que no salian a veces las citas es por que vuetify necesita dos attts (name, start) para enseñarlos. Cuando haciamos nuevas citas se hacian sin nombre.